### PR TITLE
fix urlparse import at line 8

### DIFF
--- a/abuse-ssl-bypass-waf.py
+++ b/abuse-ssl-bypass-waf.py
@@ -5,7 +5,7 @@
 
 import re
 import time
-import urlparse
+from urllib import parse as urlparse
 import argparse
 import threading
 import subprocess


### PR DESCRIPTION
Fix the import at line 8
import urlparse give the error  "object has no attribute 'urlparse' "
hence this issue can be fix by  import as
from urllib import parse as urlparse
